### PR TITLE
Fix undefined error arising when calling the `gotData` function

### DIFF
--- a/ml5js_example/sketch.js
+++ b/ml5js_example/sketch.js
@@ -58,14 +58,12 @@ function generate() {
     };
 
     // Generate text with the lstm
-    lstm.generate(data, gotData);
-
-    // Update the DOM elements with typed and generated text
-    function gotData(result) {
+    lstm.generate(data, (err,result)=>{
+      // Update the DOM elements with typed and generated text
       select('#status').html('Ready!');
       select('#original').html(original);
-      select('#prediction').html(result.generated);
-    }
+      select('#prediction').html(result);
+    });
   } else {
     // Clear everything
     select('#original').html('');


### PR DESCRIPTION
The parameter `result` is undefined when the function is called in the current way. Update to use an arrow function (could also use `,function(err,result)` as documented in ml5's [lstm.generate](https://ml5js.org/docs/LSTMGenerator) documentation. Also, note that what we display is not `result.generated`, but just `result` (result is not an object, just a string).