### PR TITLE
Use ml5 version 1.1 from July 2018

### DIFF
--- a/ml5js_example/index.html
+++ b/ml5js_example/index.html
@@ -13,7 +13,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5" type="text/javascript"></script>
+  <script src="https://cdn.jsdelivr.net/npm/ml5@0.1.1/dist/ml5.min.js"></script>
   <link rel="stylesheet" href="style.css">
 </head>
 


### PR DESCRIPTION
Instead of updating the example to use the latest ml5.js, the CDN version can be downgraded to use v0.1.1  which was release on Jul 27, 2018 which is before the ml5.LSTMGenerator() function was removed.